### PR TITLE
feat: use Flask instead of default http library

### DIFF
--- a/packages/server/requirements.txt
+++ b/packages/server/requirements.txt
@@ -1,2 +1,3 @@
 beautifulsoup4==4.9.0
+flask==1.1.2
 


### PR DESCRIPTION
# Description

Use Flask instead of default `http` library. This makes code a lot more readable and less intense.

## Motivation and Context

Tried to solve Litt's Zeit Now issue by trying to use Flask for its error handling, and really liked how the development experience was with Flask vs. the default `http` library.

## How Has This Been Tested

Run locally


<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
